### PR TITLE
Improve clipboard handling and tests

### DIFF
--- a/test_all_code.py
+++ b/test_all_code.py
@@ -178,6 +178,7 @@ if __name__ == "__main__":
     test_default_output()
     test_override_output_file()
     test_include_files()
+    test_include_files_different_cwd()
     test_extensions()
     test_exclude_dirs()
     print("All tests passed!")


### PR DESCRIPTION
## Summary
- Make clipboard copying work on macOS, Windows and Linux using platform utilities
- Treat special filenames like `Makefile` as code and clean up include structures
- Ensure CLI tests run when executing test module directly

## Testing
- `pytest -q`
- `python test_all_code.py`

------
https://chatgpt.com/codex/tasks/task_e_68a611ac7a4c8322a520f303f3df392e